### PR TITLE
Fixed doxygen documentation build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ if( ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
 endif()
 
+find_package(Doxygen)
+
 ########################################################################
 # Setup the include and linker paths
 ########################################################################


### PR DESCRIPTION
The problem is that the swig (which uses doxygen) is included
before the docs, so the doxygen is not initialized.

Resolves: #4

Signed-off-by: Jaroslav Škarvada jskarvad@redhat.com
