### PR TITLE
Unbundled hidapi

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -35,8 +35,6 @@ list(APPEND fcdproplus_sources
 
 if(APPLE)
   list(APPEND fcdproplus_sources ${CMAKE_CURRENT_SOURCE_DIR}/hid/hidmac.c)
-else()
-  list(APPEND fcdproplus_sources ${CMAKE_CURRENT_SOURCE_DIR}/hid/hid.c)
 endif()
 
 if(APPLE)
@@ -45,7 +43,8 @@ if(APPLE)
   FIND_LIBRARY(COREFOUNDATION_LIBRARY CoreFoundation)
   list(APPEND fcdproplus_libs ${COREFOUNDATION_LIBRARY})
 else()
-  list(APPEND fcdproplus_libs ${LIBUSB_LIBRARIES} )
+  FIND_LIBRARY(HIDAPI_LIBRARY hidapi-libusb)
+  list(APPEND fcdproplus_libs ${LIBUSB_LIBRARIES} ${HIDAPI_LIBRARY} )
 endif()
 
 add_library(gnuradio-fcdproplus SHARED ${fcdproplus_sources})

--- a/lib/fcdproplus_impl.h
+++ b/lib/fcdproplus_impl.h
@@ -23,7 +23,7 @@
 
 #include <fcdproplus/fcdproplus.h>
 #include <gnuradio/audio/source.h>
-#include "hidapi.h"
+#include <hidapi/hidapi.h>
 
 namespace gr {
   namespace fcdproplus {


### PR DESCRIPTION
This is what we used in Fedora to link with the system hidapi.
We used the libusb version. This could be made more robust
with e.g. autodetection, build options, etc.

Resolves: #8

Signed-off-by: Jaroslav Škarvada jskarvad@redhat.com
