### PR TITLE
Fixed soname

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,6 +66,8 @@ if(APPLE)
 endif()
 
 set_target_properties(gnuradio-fcdproplus PROPERTIES DEFINE_SYMBOL "gnuradio_fcdproplus_EXPORTS")
+set_target_properties(gnuradio-fcdproplus PROPERTIES SOVERSION 0)
+set_target_properties(gnuradio-fcdproplus PROPERTIES VERSION 0.0.0)
 
 MESSAGE(STATUS "Audio LIBS: ${GNURADIO_AUDIO_LIBRARIES}")
 


### PR DESCRIPTION
Distro inclusion requires correct soname. This adds dummy one.
It could be also assembled from the package version variable.

Signed-off-by: Jaroslav Škarvada jskarvad@redhat.com
